### PR TITLE
sh -> bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ wget ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz | tar -xvf
 ### Pipeline 
  To run the pipeline simply call:
 ```
- sh MCSC_decontamination.sh file.ini
+ bash MCSC_decontamination.sh file.ini
 ```
 
 ### Output


### PR DESCRIPTION
bash can handle variable in paths. Sh cant. eg.

FASTA=$HOME/file.fa

wont work in sh, but will in bash